### PR TITLE
Fix armhf dedicated server shutdown crash

### DIFF
--- a/include/minecraft/ServerInstance.h
+++ b/include/minecraft/ServerInstance.h
@@ -43,6 +43,7 @@ class ServerInstanceEventCoordinator {
     std::vector<ServerInstanceEventListener *> listeners;
     std::vector<mcpe::function<EventResult (ServerInstanceEventListener *)>> handlers;
     std::thread::id threadId;
+    void * filler;
 };
 
 class ServerCommunicationInterface;


### PR DESCRIPTION
leaveGameSync alters address 0 of  eduOptions to address 1
=> unique pointer frees address 1 which can't be freed

Only affects armhf shutdown crash
x86 is working with or without this patch